### PR TITLE
chore: update ghcommon workflow refs to v1.10.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   # Check for commit override flags
   check-overrides:
     name: Check Commit Overrides
-    uses: jdfalk/ghcommon/.github/workflows/commit-override-handler.yml@4afbbcef5f40921369ea5e7f36ff0d9856d03600 # main
+    uses: jdfalk/ghcommon/.github/workflows/commit-override-handler.yml@378e23a96c00d719075732dd2af4de45f7523cbb # v1.10.4
 
   # Detect what files changed to optimize workflow execution
   detect-changes:


### PR DESCRIPTION
## Summary
- Pin all `jdfalk/ghcommon` workflow references to v1.10.4 (`378e23a`)
- Replaces old SHA pins and `@main` references

## What's in ghcommon v1.10.4
- RC pre-release versioning (no more infinite update loops)
- Release sub-workflows replaced with composite actions
- Trivy removed (supply chain compromise)
- All action references SHA-pinned
- Improved language detection (fewer false positives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)